### PR TITLE
add downloaded image to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+wss-wu-dryville.jpg


### PR DESCRIPTION
Downloaded WSS Story of Dryville header image. File added to gitignore as part of exercise.

Closes #16 